### PR TITLE
Fix missing version_id by making it optional

### DIFF
--- a/src/tiptop/_info.py
+++ b/src/tiptop/_info.py
@@ -19,7 +19,7 @@ class InfoLine(Widget):
         if system == "Linux":
             ri = distro.os_release_info()
             system_list = [ri["name"]]
-            if "version_id" in ri.keys():
+            if "version_id" in ri:
                 system_list.append(ri["version_id"])
             system_list.append(f"{platform.architecture()[0]} / {platform.release()}")
             system_string = " ".join(system_list)

--- a/src/tiptop/_info.py
+++ b/src/tiptop/_info.py
@@ -18,13 +18,11 @@ class InfoLine(Widget):
         system = platform.system()
         if system == "Linux":
             ri = distro.os_release_info()
-            system_string = " ".join(
-                [
-                    ri["name"],
-                    ri["version_id"],
-                    f"{platform.architecture()[0]} / {platform.release()}",
-                ]
-            )
+            system_list = [ri["name"]]
+            if "version_id" in ri.keys():
+                system_list.append(ri["version_id"])
+            system_list.append(f"{platform.architecture()[0]} / {platform.release()}")
+            system_string = " ".join(system_list)
         elif system == "Darwin":
             system_string = f"macOS {platform.mac_ver()[0]}"
         else:


### PR DESCRIPTION
Hi @nschloe ,

fixed a bug for distros that do not have `"version_id" in distro.os_release_info().keys()`, e.g. Arch Linux. Changes might not adhere to your code style, so please check if that's okay for you.