### PR TITLE
Closes #109: Better debug info on first run

### DIFF
--- a/src/tiptop/_app.py
+++ b/src/tiptop/_app.py
@@ -97,7 +97,32 @@ def run(argv=None):
         async def on_load(self, _):
             await self.bind("q", "quit", "quit")
 
-    TiptopApp.run(log=args.log)
+    try:
+        TiptopApp.run(log=args.log)
+    except TypeError as e:
+        print(args)
+        if "run() got an unexpected keyword argument 'log'" in e.args[0]:
+            try:
+                from textual import __version__ as textual_version
+            except:
+                textual_version = "0"
+            # print in red "You're using an incorrect version of textual." Please check "https://github.com/nschloe/tiptop/issues/109"
+            debug_info = (
+                "\033[91m"
+                "You're using an incorrect version of textual.\n"
+                "Please run `pip install textual==1.9.0` to fix this.\n"
+                "Checkout https://github.com/nschloe/tiptop/issues/109 for more information!"
+            )
+
+            if textual_version != "0":
+                debug_info += (
+                    "Seems like you are right now on textual version: ", textual_version
+                )
+
+            debug_info += "\033[0m"
+
+        else:
+            raise e
 
 
 def _get_version_text():

--- a/src/tiptop/_app.py
+++ b/src/tiptop/_app.py
@@ -100,13 +100,11 @@ def run(argv=None):
     try:
         TiptopApp.run(log=args.log)
     except TypeError as e:
-        print(args)
         if "run() got an unexpected keyword argument 'log'" in e.args[0]:
             try:
                 from textual import __version__ as textual_version
             except:
                 textual_version = "0"
-            # print in red "You're using an incorrect version of textual." Please check "https://github.com/nschloe/tiptop/issues/109"
             debug_info = (
                 "\033[91m"
                 "You're using an incorrect version of textual.\n"

--- a/src/tiptop/_app.py
+++ b/src/tiptop/_app.py
@@ -108,16 +108,16 @@ def run(argv=None):
             debug_info = (
                 "\033[91m"
                 "You're using an incorrect version of textual.\n"
-                "Please run `pip install textual==1.9.0` to fix this.\n"
+                'Please run `pip install "textual>=0.1.15, <0.2"` to fix this.\n'
                 "Checkout https://github.com/nschloe/tiptop/issues/109 for more information!"
             )
 
             if textual_version != "0":
-                debug_info += (
-                    "Seems like you are right now on textual version: ", textual_version
-                )
+                debug_info += "\nSeems like you are right now on textual version: " + textual_version
 
             debug_info += "\033[0m"
+
+            print(debug_info)
 
         else:
             raise e


### PR DESCRIPTION
I am making this PR because i believe that it would help the community if things run properly on first install.

Big problem however: I tried my best to try to see if this works. I really haven't been able to test it because of these issues.

I tried:

```
pip3 install -e .
python3 -m tiptop

/Users/myusername/tiptop/myenv/bin/python3: No module named tiptop.__main__; 'tiptop' is a package and cannot be directly executed
```

I also tried:

```
tiptop
Traceback (most recent call last):
  File "/opt/homebrew/bin/tiptop", line 8, in <module>
    sys.exit(run())
             ^^^^^
  File "/opt/homebrew/lib/python3.11/site-packages/tiptop/_app.py", line 100, in run
    TiptopApp.run(log=args.log)
TypeError: App.run() got an unexpected keyword argument 'log'
```

Mind helping me test this? Apologies for asking a novice question :)
